### PR TITLE
💳 Add in Credits Scene at end #58

### DIFF
--- a/classroom_scene.go
+++ b/classroom_scene.go
@@ -248,7 +248,7 @@ func NewClassroomScene(game *Game, level int) *ClassroomScene {
 
 func (s *ClassroomScene) Update() error {
 	if s.game.debug && gpad.PressP() {
-		s.game.scene = NewHighScoreScene(s.game, 8999)
+		s.game.scene = NewHighScoreScene(s.game, 1041)
 	}
 
 	p := s.game.player

--- a/credits_scene.go
+++ b/credits_scene.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+	"github.com/ngolebiewski/play_station_41/gpad"
+)
+
+const creditsDuration = 5 * 60 // 1 seconds = 60fps
+
+type CreditsScene struct {
+	game         *Game
+	framecounter int
+}
+
+func NewCreditsScene(game *Game) *CreditsScene {
+	return &CreditsScene{
+		game:         game,
+		framecounter: 0,
+	}
+}
+
+func (s *CreditsScene) Update() error {
+	s.framecounter++
+	gpad.UpdateTouch()
+
+	// Advance after 2 seconds or on any button press
+	if s.framecounter >= creditsDuration || gpad.PressA() || gpad.PressB() || gpad.PressStart() {
+		s.game.scene = NewTitleScene(s.game)
+	}
+	return nil
+}
+
+func (s *CreditsScene) Draw(screen *ebiten.Image) {
+	// Black background
+	overlay := ebiten.NewImage(sW, sH)
+	overlay.Fill(color.RGBA{0, 0, 0, 255})
+	screen.DrawImage(overlay, &ebiten.DrawImageOptions{})
+
+	// "Credits" title
+	titleOpt := &text.DrawOptions{}
+	titleOpt.GeoM.Translate(100, 10)
+	titleOpt.ColorScale.ScaleWithColor(color.RGBA{0, 225, 0, 255})
+	text.Draw(screen, "Credits", transitionTextFace, titleOpt)
+
+	// Pixel art credit line
+	artOpt := &text.DrawOptions{}
+	artOpt.GeoM.Translate(20, 40)
+	artOpt.ColorScale.ScaleWithColor(color.RGBA{225, 225, 1, 225})
+	text.Draw(screen, "Pixel Art Self Portraits and", transitionTextFace, artOpt)
+
+	artOpt2 := &text.DrawOptions{}
+	artOpt2.GeoM.Translate(20, 55)
+	artOpt2.ColorScale.ScaleWithColor(color.RGBA{225, 225, 1, 225})
+	text.Draw(screen, "Classroom Object Art:", transitionTextFace, artOpt2)
+
+	artOpt3 := &text.DrawOptions{}
+	artOpt3.GeoM.Translate(20, 70)
+	artOpt3.ColorScale.ScaleWithColor(color.RGBA{255, 255, 255, 255})
+	text.Draw(screen, "Class 3-410 Ms. Kim and Ms. G", transitionTextFace, artOpt3)
+
+	// Game design credit line
+	designOpt := &text.DrawOptions{}
+	designOpt.GeoM.Translate(20, 90)
+	designOpt.ColorScale.ScaleWithColor(color.RGBA{225, 225, 1, 225})
+	text.Draw(screen, "Game Design, Code, Levels,", transitionTextFace, designOpt)
+
+	designOpt2 := &text.DrawOptions{}
+	designOpt2.GeoM.Translate(20, 105)
+	designOpt2.ColorScale.ScaleWithColor(color.RGBA{225, 225, 1, 225})
+	text.Draw(screen, "Classroom Art:", transitionTextFace, designOpt2)
+
+	designOpt3 := &text.DrawOptions{}
+	designOpt3.GeoM.Translate(20, 120)
+	designOpt3.ColorScale.ScaleWithColor(color.RGBA{255, 255, 255, 255})
+	text.Draw(screen, "Nick Golebiewski", transitionTextFace, designOpt3)
+
+	designOpt4 := &text.DrawOptions{}
+	designOpt4.GeoM.Translate(108, 140)
+	designOpt4.ColorScale.ScaleWithColor(color.RGBA{0, 255, 0, 255})
+	text.Draw(screen, "2026", transitionTextFace, designOpt4)
+}

--- a/high_score_scene.go
+++ b/high_score_scene.go
@@ -154,7 +154,7 @@ func (s *HighScoreScene) Update() error {
 			gp.TimerTriggered = false
 			gp.GameOver = false
 			gp.LevelComplete = false
-			s.game.scene = NewTitleScene(s.game)
+			s.game.scene = NewCreditsScene(s.game)
 		}
 
 		// Update NES message frame
@@ -364,5 +364,5 @@ func (s *HighScoreScene) drawNESMessage(screen *ebiten.Image) {
 	subOpt := &text.DrawOptions{}
 	subOpt.GeoM.Translate(float64(sW)/2-100, float64(sH)/2-10)
 	subOpt.ColorScale.ScaleWithColor(color.RGBA{200, 200, 200, 255})
-	text.Draw(screen, "RetroPI coming soon...", highScoreTextFace, subOpt)
+	text.Draw(screen, "RetroPie coming soon...", highScoreTextFace, subOpt)
 }


### PR DESCRIPTION
**Credit to the class! (and I am taking a little credit too)**

- reduce the debug amount of high score to a lower amount so it doesn't clutter the scores at top
- Note: debug shortcut is "H" to turn on debug mode, and when you are in a classroom, "P" to skip to the high score.
- add in a new credits scene.  high score scene -> credits -> start game again at title scene/menu page.